### PR TITLE
Avoid iterator_to_array() on custom iterators to fix PHP 8.5 segfault

### DIFF
--- a/src/future/FutureIterator.php
+++ b/src/future/FutureIterator.php
@@ -76,12 +76,17 @@ final class FutureIterator
     // interpret it to mean that we should iterate over whatever futures
     // remain.
 
-    if ($this->hasRewound) {
-      while ($this->valid()) {
-        $this->next();
-      }
-    } else {
-      iterator_to_array($this);
+    // NOTE: This previously used "iterator_to_array($this)" for the initial
+    // drain, but that segfaults under PHP 8.5 (null dereference inside
+    // "spl_iterator_apply"). Draining the iterator manually is equivalent --
+    // the resolved values are discarded here regardless.
+
+    if (!$this->hasRewound) {
+      $this->rewind();
+    }
+
+    while ($this->valid()) {
+      $this->next();
     }
   }
 

--- a/src/utils/PhutilArray.php
+++ b/src/utils/PhutilArray.php
@@ -22,7 +22,14 @@ abstract class PhutilArray
 
 
   public function toArray() {
-    return iterator_to_array($this, true);
+    // NOTE: This avoids "iterator_to_array($this, true)" because that
+    // segfaults under PHP 8.5 (null dereference inside "spl_iterator_apply").
+    // The manual loop preserves keys, matching the previous behavior.
+    $result = array();
+    foreach ($this as $key => $value) {
+      $result[$key] = $value;
+    }
+    return $result;
   }
 
 

--- a/src/workflow/ArcanistLintWorkflow.php
+++ b/src/workflow/ArcanistLintWorkflow.php
@@ -190,7 +190,13 @@ EOTEXT
     }
 
     if ($everything) {
-      $paths = iterator_to_array($this->getRepositoryAPI()->getAllFiles());
+      // NOTE: Avoid "iterator_to_array()" here; it segfaults under PHP 8.5
+      // (null dereference inside "spl_iterator_apply"). This manual loop
+      // preserves keys, matching the previous behavior.
+      $paths = array();
+      foreach ($this->getRepositoryAPI()->getAllFiles() as $key => $path) {
+        $paths[$key] = $path;
+      }
     } else {
       $paths = $this->selectPathsForWorkflow($paths, $rev);
     }

--- a/src/workflow/ArcanistUnitWorkflow.php
+++ b/src/workflow/ArcanistUnitWorkflow.php
@@ -143,7 +143,13 @@ EOTEXT
     }
 
     if ($everything) {
-      $paths = iterator_to_array($this->getRepositoryAPI()->getAllFiles());
+      // NOTE: Avoid "iterator_to_array()" here; it segfaults under PHP 8.5
+      // (null dereference inside "spl_iterator_apply"). This manual loop
+      // preserves keys, matching the previous behavior.
+      $paths = array();
+      foreach ($this->getRepositoryAPI()->getAllFiles() as $key => $path) {
+        $paths[$key] = $path;
+      }
     } else {
       $paths = $this->selectPathsForWorkflow($paths, $rev);
     }


### PR DESCRIPTION
## Problem

On PHP **8.5**, `iterator_to_array()` segfaults (`SIGSEGV`, `KERN_INVALID_ADDRESS at 0x18` — a null dereference inside `spl_iterator_apply`) when called on several of Arcanist's custom `Iterator` objects. This makes `arc` crash **intermittently** on machines where `php@8.5` is the active CLI interpreter. Because the affected call sites are in core paths (`FutureIterator`, the lint/unit workflows, `PhutilArray`), it hits `arc land`, `arc which`, `arc lint`, `arc unit`, etc.

Crash signature (identical across many reports):

```
EXC_BAD_ACCESS (SIGSEGV) KERN_INVALID_ADDRESS at 0x0000000000000018
  ZEND_DO_FCALL_SPEC_RETVAL_USED_TAILCALL_HANDLER
  execute_ex
  zend_call_function
  zend_call_known_function
  spl_iterator_apply
  zif_iterator_to_array
```

It is **not** a PCRE/opcache JIT issue — the crash reproduces with both JITs disabled. It does not occur under PHP 8.4.

## Fix

Replace `iterator_to_array()` with equivalent manual drains / key-preserving loops at the affected call sites:

- `src/future/FutureIterator.php` — `resolveAll()` now drains via the same `rewind()` + `while ($this->valid()) $this->next();` loop the method already uses in its post-rewind branch. The resolved values were discarded anyway.
- `src/workflow/ArcanistLintWorkflow.php` / `ArcanistUnitWorkflow.php` — build the `$paths` array with a key-preserving `foreach` over `getAllFiles()`.
- `src/utils/PhutilArray.php` — `toArray()` builds the result with a key-preserving `foreach` (equivalent to the old `iterator_to_array($this, true)`).

All changes are behavior-preserving (keys preserved where the originals preserved them).

## Validation

Using `arc which` under `php@8.5` as a harness (it exercises the working-copy path through `FutureIterator`/`PhutilArray`):

| Build | Crashes / 50 runs |
|---|---|
| upstream `master` | **3 / 50** |
| this branch | **0 / 50** |

Patched files also pass `php -l` under 8.5.