### PR TITLE
Use the id() idiom for clone chaining in ArcanistLintMessage

### DIFF
--- a/src/lint/ArcanistLintMessage.php
+++ b/src/lint/ArcanistLintMessage.php
@@ -368,7 +368,7 @@ final class ArcanistLintMessage extends Phobject {
       }
     }
 
-    return (clone $this)
+    return id(clone $this)
       ->setOriginalText($original)
       ->setReplacementText($replacement)
       ->setLine($line)


### PR DESCRIPTION
## Problem

`ArcanistLintMessage::newTrimmedMessage()` chains method calls directly on a parenthesized `clone` expression:

```php
return (clone $this)
  ->setOriginalText($original)
  ...
```

Arcanist's bundled **XHPAST** parser doesn't accept this construct, so `PhutilLibraryTestCase::testLibraryMap` (which parses every file to build the library symbol map) fails on this file:

```
FAIL  PhutilLibraryTestCase::testLibraryMap
EXCEPTION (XHPASTSyntaxErrorException): lint/ArcanistLintMessage.php:
  XHPAST Parse Error: syntax error, unexpected T_OBJECT_OPERATOR on line 372
```

## Fix

Every other `clone`/`new` method-chain in the codebase already wraps the expression in the `id()` helper precisely so XHPAST can parse it — e.g. `id(clone $template)->setX()` in `ArcanistRuntime`, `ConduitClient`, `ArcanistHardpointObject`, `ArcanistSymbolEngine`, and others (8 sites). This file was the lone outlier.

Bring it into line with that convention:

```php
return id(clone $this)
  ->setOriginalText($original)
  ...
```

`id()` simply returns its argument, so behavior is identical.

> Note: this is the same workaround arcanist already uses everywhere else, not a parser fix — `(clone $this)->…` is valid PHP that XHPAST should accept; the underlying gap is in `parser.y`. This PR just makes the file conform to the existing house idiom.

## Validation

`PhutilLibraryTestCase::testLibraryMap` goes from **FAIL** to **PASS** (verified under php@8.4); `php -l` clean.